### PR TITLE
Reinstate original auth function and injectity proofs, plus comments about evo-cr property

### DIFF
--- a/AAOSL/Abstract/Advancement.agda
+++ b/AAOSL/Abstract/Advancement.agda
@@ -775,7 +775,6 @@ module AAOSL.Abstract.Advancement where
    ...|                        inj₁ hb = inj₁ hb
    ...|                        inj₂ xx1 = inj₂ (sym xx1)
 
-
    -----------------------
    -- Membership Proofs --
    -----------------------

--- a/AAOSL/Abstract/Advancement.agda
+++ b/AAOSL/Abstract/Advancement.agda
@@ -801,6 +801,14 @@ module AAOSL.Abstract.Advancement where
    rebuildMP {j} {i} mbr t = rebuild (mbr-proof mbr)
                                      (t ∪₁ (i , auth i (mbr-datum mbr) t)) j
 
+   -- This is the proof of the Evolutionary Collision Resistance
+   -- property, as described in our CPP 2021 paper.  We have
+   -- subsequently realized that this property is less general
+   -- than the property intended (and described informally) by
+   -- Maniatis and Baker, due to the two superfluous hypotheses
+   -- annotated below.  We will soon be adding a proof for the
+   -- stronger version intended by Maniatis and Baker.
+
    evo-cr : ∀{j i₁ i₂}{t₁ t₂ : View}
           → (a₁ : AdvPath j i₁)
           → (a₂ : AdvPath j i₂)
@@ -809,8 +817,7 @@ module AAOSL.Abstract.Advancement where
           → (m₁ : MembershipProof s₁ tgt)(m₂ : MembershipProof s₂ tgt)
           → s₁ ∈AP a₁ → s₂ ∈AP a₂
           → tgt ≢ 0
-          → tgt ∈AP a₁
-          → tgt ∈AP a₂
+          → tgt ∈AP a₁ → tgt ∈AP a₂  -- Superfluous hypotheses, making evo-cr weaker than intended
           → rebuildMP m₁ u₁ ≡ rebuild a₁ t₁ s₁
           → rebuildMP m₂ u₂ ≡ rebuild a₂ t₂ s₂
           → HashBroke ⊎ (mbr-datum m₁ ≡ mbr-datum m₂)

--- a/AAOSL/Abstract/Advancement.agda
+++ b/AAOSL/Abstract/Advancement.agda
@@ -807,6 +807,7 @@ module AAOSL.Abstract.Advancement where
    -- Maniatis and Baker, due to the two superfluous hypotheses
    -- annotated below.  We will soon be adding a proof for the
    -- stronger version intended by Maniatis and Baker.
+   -- See https://github.com/oracle/aaosl-agda/issues/2
 
    evo-cr : ∀{j i₁ i₂}{t₁ t₂ : View}
           → (a₁ : AdvPath j i₁)

--- a/AAOSL/Abstract/Advancement.agda
+++ b/AAOSL/Abstract/Advancement.agda
@@ -167,11 +167,104 @@ module AAOSL.Abstract.Advancement where
    deps-hash : ℕ → View → List Hash
    deps-hash s tbl = List-map tbl (depsof s)
 
-   -- TODO-2: Make auth, auth-inj-1 and auth-inj-2 module parameters
-   -- TODO-1: Make sure the names are consistent with the paper
-
    --------------------------
    -- Defining authenticators
+   --
+   -- We need a function for computing the authenticator for a
+   -- log position given its index, a hash of its datum, and a
+   -- View that provides the authenticators for each of the
+   -- indexes' dependencies.  We also need to prove two
+   -- injectivity lemmas for this function, showing that, unless
+   -- there is a hash collision, the function is injective in
+   -- both the datum hashes and also the dependencies.
+   --
+   -- Below we define the function (called auth') as presented by
+   -- Maniatis and Baker, and prove two injectivity lemmas for
+   -- it: auth-inj-1' and auth-inj-2'.
+   --
+   -- Our development made clear that any such function that
+   -- satisfies these two injectivity properties suffices, and we
+   -- found a much simpler definition, which is presented below
+   -- (auth, auth-inj-1 and auth-inj-2), which are the ones
+   -- actually used by the rest of the proof.
+
+   -- TODO-2: Make auth, auth-inj-1 and auth-inj-2 module
+   -- parameters that can be instantiated with either version, or
+   -- any other function satisfying these properties
+
+   -- TODO-1: Make sure the names are consistent with the paper
+
+   -- Partial authenticators comes first.
+   p-auth : (i : ℕ) → Hash → Hash → Hash
+   p-auth i h hᵢ = hash (encodeI i ++ (encodeH h ++ encodeH hᵢ))
+
+   -- Together with their injectivity modulo hash collisions
+   p-auth-inj : ∀{i h}(m n : Hash) → p-auth i h m ≡ p-auth i h n
+              → HashBroke ⊎ m ≡ n
+   p-auth-inj {i} {h} m n pm≡pn
+      with hash-cr pm≡pn
+   ...| inj₁ col = inj₁ (( encodeI i ++ encodeH h ++ encodeH m
+                         , encodeI i ++ encodeH h ++ encodeH n
+                        ), col)
+   ...| inj₂ prf with ++-inj {m = encodeI i} {n = encodeI i} refl prf
+   ...|            (_ , hm≡hn) with ++-inj {m = encodeH h} {n = encodeH h} refl hm≡hn
+   ...|                          (_ , m≡n) = inj₂ ( encodeH-inj m n m≡n)
+
+   auth' : (s : ℕ) → Hash → View → Hash
+   auth' s h tbl = hash-concat (List-map (p-auth s h) (deps-hash s tbl))
+
+   auth-inj-1' : {j : ℕ}{h₁ h₂ : Hash}{t₁ t₂ : View}
+              → j ≢ 0
+              → auth' j h₁ t₁ ≡ auth' j h₂ t₂
+              → HashBroke ⊎ h₁ ≡ h₂
+   auth-inj-1' {j} {h₁} {h₂} {t₁} {t₂} j≢s₀ hip
+     with depsof j | inspect depsof j
+   ...| []       | [ R ] = ⊥-elim (j≢s₀ (depsof-ne j R))
+   ...| dj ∷ djs | _
+          with hash-concat-inj {List-map (p-auth j h₁) (List-map t₁ (dj ∷ djs))}
+                               {List-map (p-auth j h₂) (List-map t₂ (dj ∷ djs))} hip
+   ...|     inj₁ hb = inj₁ hb
+   ...|     inj₂ res
+              with ∷-injective res
+   ...|         aux , auxs
+                  with hash-cr aux
+   ...|             inj₁ col  = inj₁ (( encodeI j ++ encodeH h₁ ++ encodeH (t₁ dj)
+                                      , encodeI j ++ encodeH h₂ ++ encodeH (t₂ dj))
+                                     , col)
+   ...|             inj₂ res'
+                      with ++-injₕ {m = encodeI j} res'
+   ...|                 res''
+                            with ++-inj {m = encodeH h₁} {encodeH h₂}
+                                        (encodeH-len-lemma h₁ h₂) res''
+   ...|                       hh , ll = inj₂ (encodeH-inj h₁ h₂ hh)
+
+   auth-inj-2' : {i : ℕ}{h : Hash}(t₁ t₂ : View)
+              → auth' i h t₁ ≡ auth' i h t₂
+              → HashBroke ⊎ Agree t₁ t₂ (depsof i)
+   auth-inj-2' {i} {h} t₁ t₂ hip
+     with hash-concat-inj {List-map (p-auth i h) (List-map t₁ (depsof i))}
+                          {List-map (p-auth i h) (List-map t₂ (depsof i))} hip
+   ...| inj₁ hb  = inj₁ hb
+   ...| inj₂ res = auth-inj-2-aux {i} {h} t₁ t₂ (depsof i) res
+        where
+      auth-inj-2-aux : {i : ℕ}{h : Hash}(t₁ t₂ : View)(l : List ℕ)
+                 →  List-map (p-auth i h) (List-map t₁ l)
+                  ≡ List-map (p-auth i h) (List-map t₂ l)
+                 → HashBroke ⊎ Agree t₁ t₂ l
+      auth-inj-2-aux {i} {h} t₁ t₂ [] pl₁≡pl₂ = inj₂ []
+      auth-inj-2-aux {i} {h} t₁ t₂ (x ∷ xs) pl₁≡pl₂
+         with ∷-injective pl₁≡pl₂
+      ...| (hprf , tprf)
+           with p-auth-inj {i} {h} (t₁ x) (t₂ x) hprf
+      ...|   inj₁ hb = inj₁ hb
+      ...|   inj₂ t₁x≡t₂x
+             with auth-inj-2-aux {i} {h} t₁ t₂ xs tprf
+      ...|      inj₁ hb = inj₁ hb
+      ...|      inj₂ agreeTail = inj₂ (t₁x≡t₂x All.∷ agreeTail)
+
+   -- Next we define a much simpler variant of the auth function,
+   -- and prove that it too satisfies the required injectivity
+   -- properties.
 
    -- Authenticators will depend on all p-auths of the
    -- dependencies of a node.


### PR DESCRIPTION
We first proved the required injectivity properties for the authenticator function presented in the original paper.  Then we realised that any function satisfying these injectivity properties would suffice, and we were able to prove them for a simpler definition, which we retained.

Here, we reinstate the original proofs to record the fact that we proved them also for the version presented in the original paper.

Also adds a comment about the evo-cr property not quite being the right one.