### PR TITLE
Add original auth defn and proofs, some renaming for consistency with paper, slight simplification for EVO-CR

### DIFF
--- a/AAOSL/Abstract/Advancement.agda
+++ b/AAOSL/Abstract/Advancement.agda
@@ -672,10 +672,13 @@ module AAOSL.Abstract.Advancement
   mbr-not-init (_ , _ , m) = m
 
   -- Rebuilding it is the same as rebuilding an advancement proof, but we
-  -- explicitely compute the authenticator at i.
+  -- explicitly compute the authenticator at i.
+
+  insertAuth : View → ℕ → Hash → View
+  insertAuth t i d = t ∪₁ (i , auth i d t)
+
   rebuildMP : ∀{j i} → MembershipProof j i → View → View
-  rebuildMP {j} {i} mbr t = rebuild (mbr-proof mbr)
-                                    (t ∪₁ (i , auth i (mbr-datum mbr) t))
+  rebuildMP {j} {i} mbr t = rebuild (mbr-proof mbr) (insertAuth t i (mbr-datum mbr))
 
   semi-evo-cr : ∀{j i₁ i₂}{t₁ t₂ : View}
          → (a₁ : AdvPath j i₁)

--- a/AAOSL/Abstract/Advancement.agda
+++ b/AAOSL/Abstract/Advancement.agda
@@ -263,18 +263,18 @@ module AAOSL.Abstract.Advancement
   ∈AP-≥ (step _ hyp) = ∈AP-≥ hyp
 
 
-  rebuild-⊕' : ∀{j k i}
+  rebuild-⊕ : ∀{j k i}
              → {t : View}
              → (a₁ : AdvPath j k)
              → (a₂ : AdvPath k i)
              → ∀{l} → l ∈AP a₂
              → rebuild (a₁ ⊕ a₂) t l ≡ rebuild a₂ t l
-  rebuild-⊕' AdvDone a₂ hyp = refl
-  rebuild-⊕' {j} (AdvThere x h a₁) a₂ {l} hyp
+  rebuild-⊕ AdvDone a₂ hyp = refl
+  rebuild-⊕ {j} (AdvThere x h a₁) a₂ {l} hyp
     with j ≟ℕ l
   ...| yes nope = ⊥-elim (≤-≢-mon (hop-prog h) (hop-≤ h)
                           (≤-trans (∈AP-≤ hyp) (lemma1 a₁)) (sym nope))
-  ...| no ok    = rebuild-⊕' a₁ a₂ hyp
+  ...| no ok    = rebuild-⊕ a₁ a₂ hyp
 
   ∈AP-cut : ∀{j k i}
           → (a : AdvPath j i)
@@ -317,16 +317,7 @@ module AAOSL.Abstract.Advancement
     → ∀{t} → rebuild a t s ≡ rebuild (∈AP-cut₁ a prf) t s
   ∈AP-cut₁-rebuild a prf s∈cut {t}
     with ∈AP-cut a prf
-  ...| (x , y) , refl = rebuild-⊕' x y s∈cut
-
-  rebuild-⊕ : ∀{j k i}
-            → {t : View}
-            → (a₁ : AdvPath j k)
-            → (a₂ : AdvPath k i)
-            → rebuild (a₁ ⊕ a₂) t k ≡ rebuild a₂ t k
-  rebuild-⊕ {k = k} a₁ AdvDone = rebuild-⊕' a₁ AdvDone {k} hereTgtDone
-  rebuild-⊕ {k = k} {i = i} a₁ (AdvThere .{k} d h p) = rebuild-⊕' a₁ (AdvThere d h p) hereTgtThere
-
+  ...| (x , y) , refl = rebuild-⊕ x y s∈cut
 
   ∈AP-⊕ : ∀{j i₁ k i₂ i}
         → {e  : AdvPath j k}{a₁ : AdvPath k i₁}
@@ -522,7 +513,7 @@ module AAOSL.Abstract.Advancement
     with ≤-total (hop-tgt h₁) (hop-tgt h₂)
   ...| inj₁ h₁<h₂ with split-⊕ ≤-refl (≤∧≢⇒< h₁<h₂ (diffHop ∘ hop-tgt-inj)) go a₂
   ...| ((x , y) , refl)
-    with aoc k t₁ t₂ a₁ y (trans (witness (hop-tgt-is-dep h₁) agree) (rebuild-⊕ x y))
+    with aoc k t₁ t₂ a₁ y (trans (witness (hop-tgt-is-dep h₁) agree) (rebuild-⊕ x y ∈AP-src))
   ...| inj₁ hb  = inj₁ hb
   ...| inj₂ res = inj₂ (PMeetL x a₁ y (≤∧≢⇒< h₁<h₂ (diffHop ∘ hop-tgt-inj)) agree res)
   aoc {j = j} k t₁ t₂ (AdvThere d₁ h₁ a₁) (AdvThere d₂ h₂ a₂) hip
@@ -533,7 +524,7 @@ module AAOSL.Abstract.Advancement
      | inj₂ h₂<h₁ with split-⊕ ≤-refl (≤∧≢⇒< h₂<h₁ (diffHop ∘ hop-tgt-inj ∘ sym))
                          (≤-trans k (lemma1 a₂)) a₁
   ...| ((x , y) , refl)
-    with aoc k t₁ t₂ y a₂ (trans (sym (rebuild-⊕ x y))
+    with aoc k t₁ t₂ y a₂ (trans (sym (rebuild-⊕ x y ∈AP-src))
                                  (witness (hop-tgt-is-dep h₂) agree))
   ...| inj₁ hb  = inj₁ hb
   ...| inj₂ res = inj₂ (PMeetR x y a₂ (≤∧≢⇒< h₂<h₁ (diffHop ∘ hop-tgt-inj ∘ sym)) agree res)
@@ -609,7 +600,7 @@ module AAOSL.Abstract.Advancement
   ...| no  ok
     with aoc-correct aoc₁ (∈AP-⊕ hyp1 hyp2) hyp2
   ...| inj₁ hb = inj₁ hb
-  ...| inj₂ r  = inj₂ (trans (rebuild-⊕' e a₁ (∈AP-⊕ hyp1 hyp2)) r)
+  ...| inj₂ r  = inj₂ (trans (rebuild-⊕ e a₁ (∈AP-⊕ hyp1 hyp2)) r)
 
   aoc-correct {j} {t₁ = t₁} {t₂} (PMeetL e a₁ a₂ x₁ x₂ aoc₁) hereTgtThere hereTgtThere
     rewrite ≟ℕ-refl j
@@ -625,7 +616,7 @@ module AAOSL.Abstract.Advancement
   ...| no  ok
     with aoc-correct aoc₁ hyp1 (∈AP-⊕ hyp2 hyp1)
   ...| inj₁ hb = inj₁ hb
-  ...| inj₂ r  = inj₂ (trans r (sym (rebuild-⊕' e a₂ (∈AP-⊕ hyp2 hyp1))))
+  ...| inj₂ r  = inj₂ (trans r (sym (rebuild-⊕ e a₂ (∈AP-⊕ hyp2 hyp1))))
 
   AgreeOnCommon : ∀{j i₁ i₂}
                 → {t₁ t₂ : View}
@@ -656,9 +647,9 @@ module AAOSL.Abstract.Advancement
   AgreeOnCommon-∈ a₁ a₂ j2∈a1 hyp ia1 ia2
     with ∈AP-cut a₁ j2∈a1
   ...| ((a₁₁ , a₁₂) , refl)
-    with AgreeOnCommon a₁₂ a₂ (trans (sym (rebuild-⊕' a₁₁ a₁₂ ∈AP-src)) hyp) (∈AP-⊕ ia1 ia2) ia2
+    with AgreeOnCommon a₁₂ a₂ (trans (sym (rebuild-⊕ a₁₁ a₁₂ ∈AP-src)) hyp) (∈AP-⊕ ia1 ia2) ia2
   ...| inj₁ hb = inj₁ hb
-  ...| inj₂ res = inj₂ (trans (rebuild-⊕' a₁₁ a₁₂ (∈AP-⊕ ia1 ia2)) res)
+  ...| inj₂ res = inj₂ (trans (rebuild-⊕ a₁₁ a₁₂ (∈AP-⊕ ia1 ia2)) res)
 
 
   -----------------------

--- a/AAOSL/Abstract/Advancement.agda
+++ b/AAOSL/Abstract/Advancement.agda
@@ -771,6 +771,15 @@ module AAOSL.Abstract.Advancement
   rebuildMP : ∀{j i} → MembershipProof j i → View → View
   rebuildMP {j} {i} mbr t = rebuild (mbr-proof mbr) (insertAuth t i (mbr-datum mbr))
 
+  -- IMPORTANT NOTE: The following is the proof of the Evolutionary Collision
+  -- Resistance property, as described in our CPP 2021 paper.  We subsequently
+  -- realized that this property is less general than the property intended
+  -- (and described informally) by Maniatis and Baker, due to the two
+  -- superfluous hypotheses noted below.  We have since formulated and proved
+  -- the intended property; see AAOSL.Abstract.EvoCR.evocr.  We are working on
+  -- an extended version of the paper that is updated to reflect this change.
+  -- TODO-1: link to extended version when available.
+
   semi-evo-cr : ∀{j i₁ i₂}{t₁ t₂ : View}
          → (a₁ : AdvPath j i₁)
          → (a₂ : AdvPath j i₂)

--- a/AAOSL/Abstract/EvoCR.agda
+++ b/AAOSL/Abstract/EvoCR.agda
@@ -236,16 +236,18 @@ module AAOSL.Abstract.EvoCR
           → ∀{s₁ s₂ tgt}{u₁ u₂ : View}
           → (m₁ : MembershipProof s₁ tgt)(m₂ : MembershipProof s₂ tgt)
           → s₁ ∈AP a₁ → s₂ ∈AP a₂
-          → tgt ≢ 0 → tgt ≤ s₁ → s₁ ≤ s₂ -- wlog
+          → s₁ ≤ s₂ -- wlog
           → i₁ ≤ tgt
           → i₂ ≤ tgt
           → rebuildMP m₁ u₁ s₁ ≡ rebuild a₁ t₁ s₁
           → rebuildMP m₂ u₂ s₂ ≡ rebuild a₂ t₂ s₂
           → HashBroke ⊎ (mbr-datum m₁ ≡ mbr-datum m₂)
   evo-cr {t₁ = t₁} {t₂} a₁ a₂ hyp {s₁} {s₂} {tgt} {u₁} {u₂}
-      m₁ m₂ s₁∈a₁ s₂∈a₂ t≢0 t≤s₁ s₁≤s₂ i₁≤t i₂≤t c₁ c₂
+      m₁ m₂ s₁∈a₁ s₂∈a₂ s₁≤s₂ i₁≤t i₂≤t c₁ c₂
     with ∈AP-cut a₁ s₁∈a₁ | ∈AP-cut a₂ s₂∈a₂
   ...| ((a₁₁ , a₁₂) , refl) | ((a₂₁ , a₂₂) , refl)
+    with lemma1 (mbr-proof m₁)
+  ...| t≤s₁
   -- The first part of the proof is find some points common to three
   -- of the provided proofs. This is given in Figure 4 of Maniatis and Baker,
   -- and they are called M and R too, to help make it at least a little clear.
@@ -295,4 +297,4 @@ module AAOSL.Abstract.EvoCR
                    | rebuild-tgt-lemma (mbr-proof m₂)
                        {u₂ ∪₁ (tgt , auth tgt (mbr-datum m₂) u₂) }
   ...| l1 | l2
-    rewrite ≟ℕ-refl tgt = auth-inj-1 {tgt} {mbr-datum m₁} {mbr-datum m₂} t≢0 (trans (sym l1) (trans (sym half) l2))
+    rewrite ≟ℕ-refl tgt = auth-inj-1 {tgt} {mbr-datum m₁} {mbr-datum m₂} (mbr-not-init m₁) (trans (sym l1) (trans (sym half) l2))

--- a/AAOSL/Abstract/EvoCR.agda
+++ b/AAOSL/Abstract/EvoCR.agda
@@ -265,36 +265,38 @@ module AAOSL.Abstract.EvoCR
   -- Similarly, for a₂₂ and m₂
     with AgreeOnCommon a₂₂ (mbr-proof m₂) (trans (sym (rebuild-⊕ a₂₁ a₂₂ ∈AP-src)) (sym c₂)) M∈a₂₂ M∈m₂
   ...| inj₁ hb = inj₁ hb
-  ...| inj₂ M-a2m2
+  ...| inj₂ M-a22m2
   -- Which brings us to: rebuild a1 M == rebuild m2 M
-    with trans (trans M-a1a2 (rebuild-⊕ a₂₁ a₂₂ M∈a₂₂)) M-a2m2
+    with trans (trans M-a1a2 (rebuild-⊕ a₂₁ a₂₂ M∈a₂₂)) M-a22m2
   ...| M-a1m2
-  -- Well, if a1 and m2 agree on one point, they agree on all points. In particular, they
+  -- If a1 and m2 agree on one point, they agree on all points. In particular, they
   -- agree on R!
     with ∈AP-cut (mbr-proof m₂) M∈m₂
   ...| ((m₂₁ , m₂₂) , refl)
-    with AgreeOnCommon-∈ a₁ m₂₂ (∈AP-⊕-intro-l M∈a₁₁)
-           (trans M-a1m2 (rebuild-⊕ m₂₁ m₂₂ ∈AP-src))
+    with trans M-a1m2 (rebuild-⊕ m₂₁ m₂₂ ∈AP-src)
+  ...| M-a1m22
+    with AgreeOnCommon-∈ a₁ m₂₂ (∈AP-⊕-intro-l M∈a₁₁) M-a1m22
            (∈AP-⊕-intro-r R∈a₁₂) (∈AP-⊕-≤-r R∈m₂ (≤-trans (∈AP-≤ R∈a₁₂) (∈AP-≥ M∈a₁₁)))
   ...| inj₁ hb = inj₁ hb
-  ...| inj₂ R-a1m2
-  -- Which finally lets us argue that m1 and m2 also agree on R. Similarly, if they agree
-  -- on one point they agree on all points.
+  ...| inj₂ R-a1m22
     with AgreeOnCommon a₁₂ (mbr-proof m₁) (trans (sym (rebuild-⊕ a₁₁ a₁₂ ∈AP-src)) (sym c₁)) R∈a₁₂ R∈m₁
   ...| inj₁ hb = inj₁ hb
-  ...| inj₂ R-a1m1
-    with trans (trans (sym R-a1m2) (rebuild-⊕ a₁₁ a₁₂ R∈a₁₂)) R-a1m1
-  ...| R-m1m2
+  ...| inj₂ R-a12m1
+  -- Which finally lets us argue that m1 and m2 also agree on R. Similarly, if they agree
+  -- on one point they agree on all points.
     with ∈AP-cut (mbr-proof m₁) R∈m₁
   ...| ((m₁₁ , m₁₂) , refl)
-    with AgreeOnCommon-∈ m₂₂ m₁₂ (∈AP-⊕-≤-r R∈m₂ (≤-trans (∈AP-≤ R∈a₁₂) (∈AP-≥ M∈a₁₁)))
-           (trans R-m1m2 (rebuild-⊕ m₁₁ m₁₂ ∈AP-src)) ∈AP-tgt ∈AP-tgt
+    with trans (trans (trans (sym R-a1m22) (rebuild-⊕ a₁₁ a₁₂ R∈a₁₂)) R-a12m1) (rebuild-⊕ m₁₁ m₁₂ ∈AP-src)
+  ...| R-m22m12
+    with AgreeOnCommon-∈ m₂₂ m₁₂ (∈AP-⊕-≤-r R∈m₂ (≤-trans (∈AP-≤ R∈a₁₂) (∈AP-≥ M∈a₁₁))) R-m22m12 ∈AP-tgt ∈AP-tgt
   ...| inj₁ hb = inj₁ hb
-  ...| inj₂ res
-    with trans (rebuild-⊕ m₂₁ m₂₂ ∈AP-tgt) (trans res (sym (rebuild-⊕ m₁₁ m₁₂ ∈AP-tgt)))
-  ...| half with rebuild-tgt-lemma (mbr-proof m₁)
+  ...| inj₂ tgt-m22m12
+    with trans (rebuild-⊕ m₂₁ m₂₂ ∈AP-tgt) (trans tgt-m22m12 (sym (rebuild-⊕ m₁₁ m₁₂ ∈AP-tgt)))
+  ...| tgt-m1m2 with rebuild-tgt-lemma (mbr-proof m₁)
                        {u₁ ∪₁ (tgt , auth tgt (mbr-datum m₁) u₁) }
                    | rebuild-tgt-lemma (mbr-proof m₂)
                        {u₂ ∪₁ (tgt , auth tgt (mbr-datum m₂) u₂) }
   ...| l1 | l2
-    rewrite ≟ℕ-refl tgt = auth-inj-1 {tgt} {mbr-datum m₁} {mbr-datum m₂} (mbr-not-init m₁) (trans (sym l1) (trans (sym half) l2))
+    with trans (sym l1) (trans (sym tgt-m1m2) l2)
+  ...| auths≡
+    rewrite ≟ℕ-refl tgt = auth-inj-1 {tgt} {mbr-datum m₁} {mbr-datum m₂} (mbr-not-init m₁) auths≡

--- a/AAOSL/Abstract/EvoCR.agda
+++ b/AAOSL/Abstract/EvoCR.agda
@@ -261,35 +261,35 @@ module AAOSL.Abstract.EvoCR
   ...| inj₁ hb = inj₁ hb
   ...| inj₂ M-a1a2
   -- Similarly, for a₂₂ and m₂
-    with AgreeOnCommon a₂₂ (mbr-proof m₂) (trans (sym (rebuild-⊕' a₂₁ a₂₂ ∈AP-src)) (sym c₂)) M∈a₂₂ M∈m₂
+    with AgreeOnCommon a₂₂ (mbr-proof m₂) (trans (sym (rebuild-⊕ a₂₁ a₂₂ ∈AP-src)) (sym c₂)) M∈a₂₂ M∈m₂
   ...| inj₁ hb = inj₁ hb
   ...| inj₂ M-a2m2
   -- Which brings us to: rebuild a1 M == rebuild m2 M
-    with trans (trans M-a1a2 (rebuild-⊕' a₂₁ a₂₂ M∈a₂₂)) M-a2m2
+    with trans (trans M-a1a2 (rebuild-⊕ a₂₁ a₂₂ M∈a₂₂)) M-a2m2
   ...| M-a1m2
   -- Well, if a1 and m2 agree on one point, they agree on all points. In particular, they
   -- agree on R!
     with ∈AP-cut (mbr-proof m₂) M∈m₂
   ...| ((m₂₁ , m₂₂) , refl)
     with AgreeOnCommon-∈ a₁ m₂₂ (∈AP-⊕-intro-l M∈a₁₁)
-           (trans M-a1m2 (rebuild-⊕' m₂₁ m₂₂ ∈AP-src))
+           (trans M-a1m2 (rebuild-⊕ m₂₁ m₂₂ ∈AP-src))
            (∈AP-⊕-intro-r R∈a₁₂) (∈AP-⊕-≤-r R∈m₂ (≤-trans (∈AP-≤ R∈a₁₂) (∈AP-≥ M∈a₁₁)))
   ...| inj₁ hb = inj₁ hb
   ...| inj₂ R-a1m2
   -- Which finally lets us argue that m1 and m2 also agree on R. Similarly, if they agree
   -- on one point they agree on all points.
-    with AgreeOnCommon a₁₂ (mbr-proof m₁) (trans (sym (rebuild-⊕' a₁₁ a₁₂ ∈AP-src)) (sym c₁)) R∈a₁₂ R∈m₁
+    with AgreeOnCommon a₁₂ (mbr-proof m₁) (trans (sym (rebuild-⊕ a₁₁ a₁₂ ∈AP-src)) (sym c₁)) R∈a₁₂ R∈m₁
   ...| inj₁ hb = inj₁ hb
   ...| inj₂ R-a1m1
-    with trans (trans (sym R-a1m2) (rebuild-⊕' a₁₁ a₁₂ R∈a₁₂)) R-a1m1
+    with trans (trans (sym R-a1m2) (rebuild-⊕ a₁₁ a₁₂ R∈a₁₂)) R-a1m1
   ...| R-m1m2
     with ∈AP-cut (mbr-proof m₁) R∈m₁
   ...| ((m₁₁ , m₁₂) , refl)
     with AgreeOnCommon-∈ m₂₂ m₁₂ (∈AP-⊕-≤-r R∈m₂ (≤-trans (∈AP-≤ R∈a₁₂) (∈AP-≥ M∈a₁₁)))
-           (trans R-m1m2 (rebuild-⊕' m₁₁ m₁₂ ∈AP-src)) ∈AP-tgt ∈AP-tgt
+           (trans R-m1m2 (rebuild-⊕ m₁₁ m₁₂ ∈AP-src)) ∈AP-tgt ∈AP-tgt
   ...| inj₁ hb = inj₁ hb
   ...| inj₂ res
-    with trans (rebuild-⊕' m₂₁ m₂₂ ∈AP-tgt) (trans res (sym (rebuild-⊕' m₁₁ m₁₂ ∈AP-tgt)))
+    with trans (rebuild-⊕ m₂₁ m₂₂ ∈AP-tgt) (trans res (sym (rebuild-⊕ m₁₁ m₁₂ ∈AP-tgt)))
   ...| half with rebuild-tgt-lemma (mbr-proof m₁)
                        {u₁ ∪₁ (tgt , auth tgt (mbr-datum m₁) u₁) }
                    | rebuild-tgt-lemma (mbr-proof m₂)


### PR DESCRIPTION
This pull request:

- restores our previous definition and proof for the original auth function as defined by Maniatis and Baker (we later proved a simpler version, but we should keep this as well)
- some renaming and refactoring for consistency with the new version of the paper we're working on
- eliminate a couple of redundant assumptions in the EVO-CR proof

Supersedes #1.