### PR TITLE
Issue 6 fix

### DIFF
--- a/AAOSL/Hops.agda
+++ b/AAOSL/Hops.agda
@@ -45,11 +45,12 @@ module AAOSL.Hops where
  -- otherwise, it is one plus the number of times
  -- that two divides said index.
  --
- -- lvlOf must be marked terminating because in one branch
- -- we make recursive call on the quotient of the argument, which
- -- is not obviously smaller than that argument
- -- This is justified by proving that lvlOf is equal to lvlOfWF,
- -- which uses well-founded recursion
+ -- lvlOf must be marked terminating because, in one branch, we make a
+ -- recursive call on the quotient of the argument. Agda's termination
+ -- checker cannot confirm that this is structurally smaller than the
+ -- argument. Use of the pragma is later justified by the proof
+ -- lvlOf≡lvlOfWF that lvlOf is equal to lvlOfWF, an alternative
+ -- implementation using well-founded recursion.
  {-# TERMINATING #-}
  lvlOf : ℕ → ℕ
  lvlOf 0 = 0
@@ -61,8 +62,8 @@ module AAOSL.Hops where
  lvlOfWFHelp : (n : ℕ) → Acc _<_ n → ℕ
  lvlOfWFHelp 0 p = 0
  lvlOfWFHelp (suc n) (acc rs) with even? (suc n)
- ... | no _ = 1
- ... | yes (divides q eq) = suc (lvlOfWFHelp q (rs q (1+n=m*2⇒m<1+n q n eq)))
+ ...| no _ = 1
+ ...| yes (divides q eq) = suc (lvlOfWFHelp q (rs q (1+n=m*2⇒m<1+n q n eq)))
 
  lvlOfWF : ℕ → ℕ
  lvlOfWF n = lvlOfWFHelp n (<-wellFounded n)
@@ -79,8 +80,8 @@ module AAOSL.Hops where
  lvlOf≡lvlOfWFHelp : (n : ℕ) (p : Acc _<_ n) → lvlOf n ≡ lvlOfWFHelp n p
  lvlOf≡lvlOfWFHelp 0 p = refl
  lvlOf≡lvlOfWFHelp (suc n) (acc rs) with even? (suc n)
- ... | no _ = refl
- ... | yes (divides q eq) =
+ ...| no _ = refl
+ ...| yes (divides q eq) =
    cong suc (lvlOf≡lvlOfWFHelp q (rs q (1+n=m*2⇒m<1+n q n eq)))
 
  lvlOf≡lvlOfWF : (n : ℕ) → lvlOf n ≡ lvlOfWF n
@@ -92,10 +93,10 @@ module AAOSL.Hops where
    go : (n : ℕ) (p : Acc _<_ n) → lvlOfWFHelp n p ≡ lvlOf' (to n)
    go 0 p = refl
    go (suc n) (acc rs) with even? (suc n)
-   ... | no _ = refl
-   ... | yes (divides q eq) with go q (rs q (1+n=m*2⇒m<1+n q n eq))
-   ... | ih with to q
-   ... | pos l d odd prf = cong suc ih
+   ...| no _ = refl
+   ...| yes (divides q eq) with go q (rs q (1+n=m*2⇒m<1+n q n eq))
+   ...| ih with to q
+   ...| pos l d odd prf = cong suc ih
 
  lvl≥2-even : ∀ {n} → 2 ≤ lvlOf n → Even n
  lvl≥2-even {suc n} x

--- a/AAOSL/Hops.agda
+++ b/AAOSL/Hops.agda
@@ -10,6 +10,7 @@ open import Data.Sum
 open import Data.Nat
 open import Data.Nat.Divisibility
 open import Data.Nat.Properties
+open import Data.Nat.Induction
 open import Data.List renaming (map to List-map)
 open import Data.List.Relation.Unary.Any
 open import Data.List.Relation.Unary.All
@@ -43,13 +44,28 @@ module AAOSL.Hops where
  -- The level of an index is 0 for index 0,
  -- otherwise, it is one plus the number of times
  -- that two divides said index.
- -- TODO-1: document reasons for this pragma and justify it
+ --
+ -- lvlOf must be marked terminating because in one branch
+ -- we make recursive call on the quotient of the argument, which
+ -- is not obviously smaller than that argument
+ -- This is justified by proving that lvlOf is equal to lvlOfWF,
+ -- which uses well-founded recursion
  {-# TERMINATING #-}
  lvlOf : ℕ → ℕ
  lvlOf 0 = 0
- lvlOf (suc n) with 2 ∣? (suc n)
+ lvlOf (suc n) with even? (suc n)
  ...| no  _ = 1
  ...| yes e = suc (lvlOf (quotient e))
+
+ -- level of an index with well-founded recursion
+ lvlOfWFHelp : (n : ℕ) → Acc _<_ n → ℕ
+ lvlOfWFHelp 0 p = 0
+ lvlOfWFHelp (suc n) (acc rs) with even? (suc n)
+ ... | no _ = 1
+ ... | yes (divides q eq) = suc (lvlOfWFHelp q (rs q (1+n=m*2⇒m<1+n q n eq)))
+
+ lvlOfWF : ℕ → ℕ
+ lvlOfWF n = lvlOfWFHelp n (<-wellFounded n)
 
  -- When looking at an index in the form 2^k * d, the level of
  -- said index is more easily defined.
@@ -58,19 +74,28 @@ module AAOSL.Hops where
  lvlOf' (pos l _ _ _) = suc l
 
 
- ---------------------------------
- -- Properties of lvlOf and lvlOf'
+ -------------------------------------------
+ -- Properties of lvlOf, lvlOfWF, and lvlOf'
+ lvlOf≡lvlOfWFHelp : (n : ℕ) (p : Acc _<_ n) → lvlOf n ≡ lvlOfWFHelp n p
+ lvlOf≡lvlOfWFHelp 0 p = refl
+ lvlOf≡lvlOfWFHelp (suc n) (acc rs) with even? (suc n)
+ ... | no _ = refl
+ ... | yes (divides q eq) =
+   cong suc (lvlOf≡lvlOfWFHelp q (rs q (1+n=m*2⇒m<1+n q n eq)))
 
- -- TODO-1: document reasons for this pragma and justify it
- {-# TERMINATING #-}
+ lvlOf≡lvlOfWF : (n : ℕ) → lvlOf n ≡ lvlOfWF n
+ lvlOf≡lvlOfWF n = lvlOf≡lvlOfWFHelp n (<-wellFounded n)
+
  lvlOf≡lvlOf' : ∀ n → lvlOf n ≡ lvlOf' (to n)
- lvlOf≡lvlOf' zero = refl
- lvlOf≡lvlOf' (suc n) with even? (suc n)
- ...| no  odd = refl
- ...| yes prf with lvlOf≡lvlOf' (quotient prf)
- ...| ind with to (quotient prf)
- ...| zero = ⊥-elim (1+n≢0 (_∣_.equality prf))
- ...| pos l d odd prf' = cong suc ind
+ lvlOf≡lvlOf' n rewrite lvlOf≡lvlOfWF n = go n (<-wellFounded n)
+   where
+   go : (n : ℕ) (p : Acc _<_ n) → lvlOfWFHelp n p ≡ lvlOf' (to n)
+   go 0 p = refl
+   go (suc n) (acc rs) with even? (suc n)
+   ... | no _ = refl
+   ... | yes (divides q eq) with go q (rs q (1+n=m*2⇒m<1+n q n eq))
+   ... | ih with to q
+   ... | pos l d odd prf = cong suc ih
 
  lvl≥2-even : ∀ {n} → 2 ≤ lvlOf n → Even n
  lvl≥2-even {suc n} x

--- a/AAOSL/Lemmas.agda
+++ b/AAOSL/Lemmas.agda
@@ -151,6 +151,18 @@ module AAOSL.Lemmas where
  +-*-suc' m n with *-suc m n
  ...| xx rewrite *-comm n m = xx
 
+ ----------------------------------
+ -- Properties of divisibility by 2
+
+ 1+n=m*2⇒m<1+n : ∀ m n → 1 + n ≡ m * 2 → m < 1 + n
+ 1+n=m*2⇒m<1+n (suc zero) (suc n) eq = s≤s (s≤s z≤n)
+ 1+n=m*2⇒m<1+n (suc (suc m)) (suc (suc n)) eq = s≤s (<-trans ih (n<1+n (1 + n)))
+   where
+   eq' : 1 + n ≡ (1 + m) * 2
+   eq' = +-cancelˡ-≡ 2 eq
+
+   ih : (1 + m) < 1 + n
+   ih = 1+n=m*2⇒m<1+n (1 + m) n eq'
 
  -------------------------------
  -- Properties of exponentiation

--- a/README.md
+++ b/README.md
@@ -35,5 +35,6 @@ As of the beginning of this repo, contributions have been made by
 [Victor Cacciari Miraldo](https://github.com/VictorCMiraldo), [Harold Carr](https://github.com/haroldcarr), [Mark Moir](https://github.com/mark-moir), and [Lisandra Silva](https://github.com/lisandrasilva), all while employed at Oracle Labs.
 
 We are grateful to the following people for contributions since then:
+* [Chris Jenkins](https://github.com/cwjnkins)
 * `[your name here]`
 


### PR DESCRIPTION
This PR implements the proposal for a well-founded `lvlOf` described in #6 
In particular:

- adds a lemma in `AAOSL/Lemmas.agda` that quotients from a dividing a positive number by 2 are less than the dividend
- adds `lvlOfWF`, which computes an index level using well-founded recursion
- proves `lvlOfWF` is extensionally equal to `lvlOf`
- uses the above proof in the justification of the `TERMINATING` pragma used on `lvlOf`
- amends the proof that `lvlOf` is extensionally equal to `lvlOf`' so that the `TERMINATING` pragma is no longer needed 